### PR TITLE
Change the implementation for NMS

### DIFF
--- a/facexlib/detection/retinaface_utils.py
+++ b/facexlib/detection/retinaface_utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import torch
+import torchvision
 from itertools import product as product
 from math import ceil
 
@@ -37,31 +38,9 @@ class PriorBox(object):
 
 def py_cpu_nms(dets, thresh):
     """Pure Python NMS baseline."""
-    x1 = dets[:, 0]
-    y1 = dets[:, 1]
-    x2 = dets[:, 2]
-    y2 = dets[:, 3]
-    scores = dets[:, 4]
-
-    areas = (x2 - x1 + 1) * (y2 - y1 + 1)
-    order = scores.argsort()[::-1]
-
-    keep = []
-    while order.size > 0:
-        i = order[0]
-        keep.append(i)
-        xx1 = np.maximum(x1[i], x1[order[1:]])
-        yy1 = np.maximum(y1[i], y1[order[1:]])
-        xx2 = np.minimum(x2[i], x2[order[1:]])
-        yy2 = np.minimum(y2[i], y2[order[1:]])
-
-        w = np.maximum(0.0, xx2 - xx1 + 1)
-        h = np.maximum(0.0, yy2 - yy1 + 1)
-        inter = w * h
-        ovr = inter / (areas[i] + areas[order[1:]] - inter)
-
-        inds = np.where(ovr <= thresh)[0]
-        order = order[inds + 1]
+    keep = torchvision.ops.nms(
+        boxes=dets[:, :4], scores=dets[:, 4], iou_threshold=thresh
+    )
 
     return keep
 

--- a/facexlib/detection/retinaface_utils.py
+++ b/facexlib/detection/retinaface_utils.py
@@ -39,7 +39,9 @@ class PriorBox(object):
 def py_cpu_nms(dets, thresh):
     """Pure Python NMS baseline."""
     keep = torchvision.ops.nms(
-        boxes=dets[:, :4], scores=dets[:, 4], iou_threshold=thresh
+        boxes=torch.Tensor(dets[:, :4]),
+        scores=torch.Tensor(dets[:, 4]),
+        iou_threshold=thresh,
     )
 
     return keep

--- a/facexlib/detection/retinaface_utils.py
+++ b/facexlib/detection/retinaface_utils.py
@@ -44,7 +44,7 @@ def py_cpu_nms(dets, thresh):
         iou_threshold=thresh,
     )
 
-    return keep
+    return list(keep)
 
 
 def point_form(boxes):


### PR DESCRIPTION
Fix #9 by switching to [`torchvision`'s implementation of NMS](https://pytorch.org/vision/stable/ops.html#torchvision.ops.nms).

---

I have tested the code on Google Colab with a GPU, using:
```bash
branch = "nms"

%cd /content
!git clone https://github.com/woctezuma/facexlib.git

%cd /content/facexlib
!git checkout {branch}

%pip install --quiet -e .
```

The code works fine with this example with 3 faces:
```bash
!wget -O /content/input.jpg https://raw.githubusercontent.com/ternaus/retinaface/master/tests/data/13.jpg

!python inference/inference_detection.py --img_path /content/input.jpg
```

The code also works fine with the default example with 1 face:
```bash
!python inference/inference_detection.py --img_path /content/facexlib/assets/test.jpg
```

Ditto with a more extreme case with many faces:
```bash
!wget -O /content/crowd.jpg https://i.imgur.com/j4KK3i4.jpeg

!python inference/inference_detection.py --img_path /content/crowd.jpg
```

---

I have timed both implementations:
- after downloading the model checkpoint,
- by repeating the runs 10 times each,
- using the following kind of code:
```python
import time

start_time = time.time()
for i in range(10):
  !python inference/inference_detection.py --img_path /content/input.jpg > /dev/null
print("--- %s seconds ---" % (time.time() - start_time))
```

Results:
- using the `master` branch:
   - using `input.jpg`: 41.409 seconds
   - using `test.jpg`: 40.496 seconds
   - using `crowd.jpg`: 62.800 seconds
- using the `nms` branch:
   - using `input.jpg`: 41.702 seconds (a bit worse)
   - using `test.jpg`: 40.405 seconds (a bit better)
   - using `crowd.jpg`: 63.107 seconds (a bit worse)

So the run time is extremely similar, at least for cases with a few faces.

**However**, I would expect to see some benefits in some scenarii, right? :)
And no drawback as the package requirement was already there.