### PR TITLE
Bug: Changed float to float64 for newer numpy

### DIFF
--- a/facexlib/alignment/awing_arch.py
+++ b/facexlib/alignment/awing_arch.py
@@ -15,7 +15,7 @@ def calculate_points(heatmaps):
     indexes = np.argmax(heatline, axis=2)
 
     preds = np.stack((indexes % W, indexes // W), axis=2)
-    preds = preds.astype(np.float, copy=False)
+    preds = preds.astype(np.float64, copy=False)
 
     inr = indexes.ravel()
 


### PR DESCRIPTION
Numpy 1.23+ was crashing because of the np.float value.
This fixes the possible crash/block using the recommended change.

# Error:
```
File "f:\Env\Lib\site-packages\numpy\__init__.py
", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in e
xisting code, use `float` by itself. Doing this will not modify any behavior and is
 safe. If you specifically wanted the numpy scalar type, use `np.float64` here.    
The aliases was originally deprecated in NumPy 1.20; for more details and guidance 
see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```