### PR TITLE
Fix compatibility issues with NumPy

### DIFF
--- a/facexlib/alignment/awing_arch.py
+++ b/facexlib/alignment/awing_arch.py
@@ -15,7 +15,7 @@ def calculate_points(heatmaps):
     indexes = np.argmax(heatline, axis=2)
 
     preds = np.stack((indexes % W, indexes // W), axis=2)
-    preds = preds.astype(np.float, copy=False)
+    preds = preds.astype(float, copy=False)
 
     inr = indexes.ravel()
 


### PR DESCRIPTION
Address the issue where facexlib was constrained to using older versions of NumPy, leading to unnecessary version conflicts with other dependencies.
The updates made here enhance compatibility, allowing us to use more recent versions of NumPy without the need for downgrading.